### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-nightly-build-actions.yml
+++ b/.github/workflows/gradle-nightly-build-actions.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/datenkollektiv/spring-boot-kisses-angular/security/code-scanning/1](https://github.com/datenkollektiv/spring-boot-kisses-angular/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block that grants the minimum permissions required for this job. The workflow needs to read the repository (for checkout) and also create/update releases and tags via `djnicholson/release-action`, which relies on `GITHUB_TOKEN` with `contents: write`. No other scopes (like `issues`, `pull-requests`, etc.) are needed based on the shown steps.

The best minimal fix without changing existing functionality is to add a `permissions` section under the `build` job in `.github/workflows/gradle-nightly-build-actions.yml`, just above `runs-on`. Set it to:

```yaml
permissions:
  contents: write
```

This constrains the token to repository contents operations only and ensures the release action still works. No additional imports, methods, or definitions are needed beyond this edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
